### PR TITLE
Update task status in the DB

### DIFF
--- a/lambda/sqs_embedding_task_consumer/lambda_function.py
+++ b/lambda/sqs_embedding_task_consumer/lambda_function.py
@@ -90,9 +90,13 @@ def lambda_handler(event, context):
 
                 db.store(video_metadata, video_segments)
                 logger.info("Successfully stored video and segments in DB")
+                db.update_task_status(message_id, "completed")
+                logger.info("Successfully updated task status in DB")
 
             elif task_status == "failed":
                 logger.error(f"TwelveLabs video embedding task failed: {message_body}")
+                db.update_task_status(message_id, "failed")
+                logger.info("Successfully updated task status in DB")
 
             elif task_status == "processing":
                 # If status is "processing", add to pending list for re-queuing
@@ -101,11 +105,15 @@ def lambda_handler(event, context):
                     f"TwelveLabs video embedding task {tl_task_id} is still pending. Re-queueing."
                 )
             else:
+                db.update_task_status(message_id, "failed")
+                logger.info("Successfully updated task status in DB")
                 raise Exception(f"Unexpected value for task status {task_status}")
 
         except Exception as e:
             logger.error(f"Error processing task {message_id}: {e}")
             pending_message_ids.append({"itemIdentifier": message_id})
+            db.update_task_status(message_id, "retrying")
+            logger.info("Successfully updated task status in DB")
 
     # Return the list of pending message IDs
     if pending_message_ids:

--- a/lambda/sqs_embedding_task_consumer/lambda_function.py
+++ b/lambda/sqs_embedding_task_consumer/lambda_function.py
@@ -105,8 +105,6 @@ def lambda_handler(event, context):
                     f"TwelveLabs video embedding task {tl_task_id} is still pending. Re-queueing."
                 )
             else:
-                db.update_task_status(message_id, "failed")
-                logger.info("Successfully updated task status in DB")
                 raise Exception(f"Unexpected value for task status {task_status}")
 
         except Exception as e:


### PR DESCRIPTION
This PR includes:
- Updating task status in the DB from the `sqs_embedding_task_consumer` lambda

Checked the status in the DB and it looks like this:

<img width="1156" height="101" alt="Screenshot 2025-07-25 at 8 39 57 am" src="https://github.com/user-attachments/assets/216f4111-8351-4bdc-bc62-d6c529d44472" />
<img width="1178" height="148" alt="Screenshot 2025-07-25 at 8 40 12 am" src="https://github.com/user-attachments/assets/02f486e6-bc4a-4bc1-8de3-8fd89855be9f" />
<img width="1182" height="155" alt="Screenshot 2025-07-25 at 8 40 36 am" src="https://github.com/user-attachments/assets/1c62cca2-76eb-480d-a56e-4186d3c57d85" />
<img width="1174" height="154" alt="Screenshot 2025-07-25 at 8 40 49 am" src="https://github.com/user-attachments/assets/cf4f777c-7935-47ad-8762-64b9c0e2af5e" />
