### PR TITLE
feat: added s3 resource and IAM roles to terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,9 @@ override.tf.json
 .terraformrc
 terraform.rc
 
+# ignore the videos in the terraform videos folder
+terraform/modules/s3/videos
+
 package.zip
 **/package.zip
 package/

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,3 +4,15 @@ module "vpc_network" {
   env                     = local.env
   region                  = local.region
 }
+module "s3" {
+  source = "./modules/s3"
+}
+
+module "iam" {
+  source = "./modules/iam"
+
+  s3_bucket_arn = module.s3.bucket_arn
+  environment   = local.env
+
+  depends_on = [module.s3]
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -31,7 +31,7 @@ resource "aws_iam_policy" "lambda_s3_readonly" {
       {
         Effect = "Allow"
         Action = [
-          "s3:GetObject",
+          # "s3:GetObject",
           "s3:ListBucket",
           "s3:GetBucketLocation"
         ]

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,0 +1,136 @@
+resource "aws_iam_role" "lambda_s3_readonly" {
+  name = "kubrick-lambda-s3-readonly-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "kubrick-lambda-s3-readonly-role"
+    Environment = var.environment
+    Purpose     = "Lambda S3 Read-Only Access"
+  }
+}
+
+resource "aws_iam_policy" "lambda_s3_readonly" {
+  name        = "kubrick-lambda-s3-readonly-policy"
+  description = "Policy for Lambda functions to have read-only access to S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          var.s3_bucket_arn,
+          "${var.s3_bucket_arn}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "kubrick-lambda-s3-readonly-policy"
+    Environment = var.environment
+  }
+}
+
+# Attach Read-Only Policy to Read-Only Role
+resource "aws_iam_role_policy_attachment" "lambda_s3_readonly" {
+  role       = aws_iam_role.lambda_s3_readonly.name
+  policy_arn = aws_iam_policy.lambda_s3_readonly.arn
+}
+
+resource "aws_iam_role" "lambda_s3_full_access" {
+  name = "kubrick-lambda-s3-full-access-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "kubrick-lambda-s3-full-access-role"
+    Environment = var.environment
+    Purpose     = "Lambda S3 Full Access"
+  }
+}
+
+resource "aws_iam_policy" "lambda_s3_full_access" {
+  name        = "kubrick-lambda-s3-full-access-policy"
+  description = "Policy for Lambda functions to have full access to S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+          "s3:GetObjectVersion",
+          "s3:DeleteObjectVersion",
+          "s3:ListBucketVersions"
+        ]
+        Resource = [
+          var.s3_bucket_arn,
+          "${var.s3_bucket_arn}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "kubrick-lambda-s3-full-access-policy"
+    Environment = var.environment
+  }
+}
+
+# Attach Full Access Policy to Full Access Role
+resource "aws_iam_role_policy_attachment" "lambda_s3_full_access" {
+  role       = aws_iam_role.lambda_s3_full_access.name
+  policy_arn = aws_iam_policy.lambda_s3_full_access.arn
+}

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,0 +1,29 @@
+output "lambda_s3_readonly_role_arn" {
+  description = "ARN of the Lambda S3 read-only IAM role"
+  value       = aws_iam_role.lambda_s3_readonly.arn
+}
+
+output "lambda_s3_readonly_role_name" {
+  description = "Name of the Lambda S3 read-only IAM role"
+  value       = aws_iam_role.lambda_s3_readonly.name
+}
+
+output "lambda_s3_full_access_role_arn" {
+  description = "ARN of the Lambda S3 full access IAM role"
+  value       = aws_iam_role.lambda_s3_full_access.arn
+}
+
+output "lambda_s3_full_access_role_name" {
+  description = "Name of the Lambda S3 full access IAM role"
+  value       = aws_iam_role.lambda_s3_full_access.name
+}
+
+output "lambda_s3_readonly_policy_arn" {
+  description = "ARN of the Lambda S3 read-only policy"
+  value       = aws_iam_policy.lambda_s3_readonly.arn
+}
+
+output "lambda_s3_full_access_policy_arn" {
+  description = "ARN of the Lambda S3 full access policy"
+  value       = aws_iam_policy.lambda_s3_full_access.arn
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -6,5 +6,4 @@ variable "s3_bucket_arn" {
 variable "environment" {
   description = "Environment name (e.g., dev, staging, prod)"
   type        = string
-  default     = "dev"
 }

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,0 +1,10 @@
+variable "s3_bucket_arn" {
+  description = "ARN of the S3 bucket that Lambda functions will access"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -1,0 +1,36 @@
+# Generate a random UUID for unique bucket naming
+resource "random_id" "bucket_suffix" {
+  byte_length = 8
+}
+
+# S3 Bucket with UUID-based naming
+resource "aws_s3_bucket" "kubrick_video_upload_bucket" {
+  bucket = "kubrick-video-library-${random_id.bucket_suffix.hex}"
+  force_destroy = true
+}
+
+# S3 Bucket Public Access Block
+resource "aws_s3_bucket_public_access_block" "kubrick_video_upload_bucket" {
+  bucket = aws_s3_bucket.kubrick_video_upload_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# resource "aws_s3_object" "upload_videos" {
+#   for_each = fileset("${path.module}/videos", "**")
+#   bucket   = aws_s3_bucket.kubrick_video_upload_bucket.id
+#   key      = each.key
+#   source   = "${path.module}/videos/${each.value}"
+#   etag     = filemd5("${path.module}/videos/${each.value}")
+  
+#   # Set content type based on file extension
+#   content_type = lookup({
+#     "mp4"  = "video/mp4"
+#     "webm" = "video/webm"
+#     "avi"  = "video/x-msvideo"
+#     "mov"  = "video/quicktime"
+#   }, lower(split(".", each.value)[length(split(".", each.value)) - 1]), "application/octet-stream")
+# }

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,0 +1,19 @@
+output "bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.kubrick_video_upload_bucket.bucket
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.kubrick_video_upload_bucket.arn
+}
+
+output "bucket_id" {
+  description = "ID of the S3 bucket"
+  value       = aws_s3_bucket.kubrick_video_upload_bucket.id
+}
+
+output "bucket_domain_name" {
+  description = "Domain name of the S3 bucket"
+  value       = aws_s3_bucket.kubrick_video_upload_bucket.bucket_domain_name
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,52 @@
+# S3 Bucket Outputs
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = module.s3.bucket_name
+}
+
+output "s3_bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = module.s3.bucket_arn
+}
+
+output "s3_bucket_id" {
+  description = "ID of the S3 bucket"
+  value       = module.s3.bucket_id
+}
+
+output "s3_bucket_domain_name" {
+  description = "Domain name of the S3 bucket"
+  value       = module.s3.bucket_domain_name
+}
+
+# Lambda IAM Role Outputs
+output "lambda_s3_readonly_role_arn" {
+  description = "ARN of the Lambda S3 read-only IAM role"
+  value       = module.iam.lambda_s3_readonly_role_arn
+}
+
+output "lambda_s3_readonly_role_name" {
+  description = "Name of the Lambda S3 read-only IAM role"
+  value       = module.iam.lambda_s3_readonly_role_name
+}
+
+output "lambda_s3_full_access_role_arn" {
+  description = "ARN of the Lambda S3 full access IAM role"
+  value       = module.iam.lambda_s3_full_access_role_arn
+}
+
+output "lambda_s3_full_access_role_name" {
+  description = "Name of the Lambda S3 full access IAM role"
+  value       = module.iam.lambda_s3_full_access_role_name
+}
+
+# IAM Policy Outputs
+output "lambda_s3_readonly_policy_arn" {
+  description = "ARN of the Lambda S3 read-only policy"
+  value       = module.iam.lambda_s3_readonly_policy_arn
+}
+
+output "lambda_s3_full_access_policy_arn" {
+  description = "ARN of the Lambda S3 full access policy"
+  value       = module.iam.lambda_s3_full_access_policy_arn
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = local.region
-  profile = "AdministratorAccess-791237609017-Dom"
+  # profile = "AdministratorAccess-791237609017-Dom"
 }
 
 terraform {


### PR DESCRIPTION
- added s3 resource to terraform
- created a s3 read-only role in IAM
- created a s3 read-only policy in IAM
- attached read-only policy to read-only role
- created a s3 full-access role in IAM
- created a s3 full-access policy in IAM
- attached full-access policy to full-access role

Note - i added code to uploaded videos from a video folder in the s3 terraform module - this is more to make life a bit easier for us when testing but I think it should be removed in the final version.