### PR TITLE
Secret refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,6 +249,9 @@ terraform.rc
 # ignore the videos in the terraform videos folder
 terraform/modules/s3/videos
 
+# ignore db_bootstrap response
+terraform/output.json
+
 package.zip
 **/package.zip
 package/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 80,
+  "proseWrap": "always",
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/README.md
+++ b/README.md
@@ -1,50 +1,62 @@
 # Kubrick
 
 ## Terraform Installation Guide
-The Kubrick Terraform directory provides everything you need to set up Kubrick in a production environment. Using Terraform, you can deploy the required AWS infrastructure, which include: Lambdas, API Gateway, CloudFront, S3, SQS, and RDS. This guide will walk you throw provisioning Kubrick's architecture using Terraform.
+
+The Kubrick Terraform directory provides everything you need to set up Kubrick
+in a production environment. Using Terraform, you can deploy the required AWS
+infrastructure, which include: Lambdas, API Gateway, CloudFront, S3, SQS, and
+RDS. This guide will walk you throw provisioning Kubrick's architecture using
+Terraform.
 
 ### Getting Started
+
 To deploy Kubrick in your AWS account, follow these steps:
+
 1. Install Prerequisites:
 
 - [Install Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
 - [Install AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html#getting-started-install-instructions)
 
 2. Clone the Repository:
+
 ```
 cd clone https://github.com/kubrick-ai/kubrick.git
 cd kubrick/terraform
 ```
 
 ### Setting Up Secrets
-Kubrick uses AWS Secrets Manager to securely store sensitive information like database credentials and your TwelveLabs API key.
 
-1. **Create Credentials**: Run the following command to create a secret for your PostgreSQL database credentials and TwelveLabs API key. Replace the values as necessary:
+Kubrick uses AWS Secrets Manager to securely store sensitive information like
+database credentials and your TwelveLabs API key.
+
+1. **Create Credentials**: Run the following command to create a secret for your
+   PostgreSQL database credentials and TwelveLabs API key. Replace the values as
+   necessary:
+
 ```
 aws secretsmanager create-secret \
-    --region us-east-2 \
-    --name "kubrick_secrets" \
-    --description "Secrets for Kubrick application" \
+    --region <aws_region> \
+    --name "kubrick_secret" \
+    --description "Secret store for Kubrick application" \
     --secret-string '{
-        "database": {
-            "username": "db_username",
-            "password": "db_password"
-        },
-        "api_keys": {
-            "twelvelabs": "twelvelabs_key"
-        }
+        "DB_USERNAME": <db_username>,
+        "DB_PASSWORD": <db_password>
+        "TWELVELABS_API_KEY": <twelvelabs_API_key>
     }'
 ```
 
-- `us-east-2`     : Replace with your AWS region
-- `db_username`   : Replace with your PostgreSQL username.
-- `db_password`   : Replace with your PostgreSQL password.
-- `twelvelabs_key`: Replace with your TwelveLabs API key.
+- `<aws_region>` : Replace with your AWS region (e.g., `us-east-2`)
+- `db_username` : Replace with your PostgreSQL username (e.g., `postgres`).
+- `db_password` : Replace with your PostgreSQL password.
+- `twelvelabs_API_key`: Replace with your TwelveLabs API key.
 
 ### Deploying Kubrick
-1. **Initialize Terraform**: Run the following command to set your AWS region and provision the architecture:
-```terraform init```
 
-2. **Apply the Terraform Configuration**: Run the following command to set your AWS region and provision the architecture:
+1. **Initialize Terraform**: Run the following command to set your AWS region
+   and provision the architecture: `terraform init`
+
+2. **Apply the Terraform Configuration**: Run the following command to set your
+   AWS region and provision the architecture:
 
 // TODO
+

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ aws secretsmanager create-secret \
     --description "Secret store for Kubrick application" \
     --secret-string '{
         "DB_USERNAME": <db_username>,
-        "DB_PASSWORD": <db_password>
+        "DB_PASSWORD": <db_password>,
         "TWELVELABS_API_KEY": <twelvelabs_API_key>
     }'
 ```
@@ -59,4 +59,3 @@ aws secretsmanager create-secret \
    AWS region and provision the architecture:
 
 // TODO
-

--- a/lambda/api_fetch_tasks_handler/build-package.sh
+++ b/lambda/api_fetch_tasks_handler/build-package.sh
@@ -15,9 +15,6 @@ uv pip install --target package/ --python-platform x86_64-unknown-linux-gnu --py
 # Copy Python source files to package directory
 cp *.py package/
 
-# Copy config JSON to package directory
-cp config.json package/
-
 # Create a zip file containing everything from the package directory at the zip root
 cd package
 zip -r ../${PACKAGE_NAME}.zip .

--- a/lambda/api_fetch_tasks_handler/config.json
+++ b/lambda/api_fetch_tasks_handler/config.json
@@ -1,6 +1,0 @@
-{
-  "secret_name": "kubrick_secret",
-  "default_limit": 10,
-  "max_limit": 50,
-  "default_page": 0
-}

--- a/lambda/api_fetch_tasks_handler/config.json
+++ b/lambda/api_fetch_tasks_handler/config.json
@@ -1,5 +1,5 @@
 {
-  "secret_name": "KubrickEmbeddingTaskConsumerSecret",
+  "secret_name": "kubrick_secret",
   "default_limit": 10,
   "max_limit": 50,
   "default_page": 0

--- a/lambda/api_fetch_videos_handler/build-package.sh
+++ b/lambda/api_fetch_videos_handler/build-package.sh
@@ -15,9 +15,6 @@ uv pip install --target package/ --python-platform x86_64-unknown-linux-gnu --py
 # Copy Python source files to package directory
 cp *.py package/
 
-# Copy config JSON to package directory
-cp config.json package/
-
 # Create a zip file containing everything from the package directory at the zip root
 cd package
 zip -r ../${PACKAGE_NAME}.zip .

--- a/lambda/api_fetch_videos_handler/config.json
+++ b/lambda/api_fetch_videos_handler/config.json
@@ -1,4 +1,4 @@
 {
-  "presigned_url_expiry": 86400,
-  "secret_name": "KubrickEmbeddingTaskConsumerSecret"
+  "secret_name": "kubrick_secret",
+  "presigned_url_expiry": 86400
 }

--- a/lambda/api_fetch_videos_handler/config.json
+++ b/lambda/api_fetch_videos_handler/config.json
@@ -1,4 +1,0 @@
-{
-  "secret_name": "kubrick_secret",
-  "presigned_url_expiry": 86400
-}

--- a/lambda/api_fetch_videos_handler/lambda_function.py
+++ b/lambda/api_fetch_videos_handler/lambda_function.py
@@ -1,4 +1,5 @@
-from config import load_config, get_secret, setup_logging, get_db_config
+import os
+from config import get_secret, setup_logging, get_db_config
 from vector_db_service import VectorDBService
 from response_utils import (
     build_error_response,
@@ -6,12 +7,15 @@ from response_utils import (
     add_presigned_urls,
 )
 
+# Environment variables
+SECRET_NAME = os.getenv("SECRET_NAME", "kubrick_secret")
+PRESIGNED_URL_EXPIRY = int(os.getenv("PRESIGNED_URL_EXPIRY", "86400"))
+
 
 def lambda_handler(event, context):
     logger = setup_logging()
     try:
-        config = load_config()
-        SECRET = get_secret(config)
+        SECRET = get_secret(SECRET_NAME)
         DB_CONFIG = get_db_config(SECRET)
         logger.debug(f"event={event}")
         query_params = event.get("queryStringParameters") or {}
@@ -22,7 +26,7 @@ def lambda_handler(event, context):
         logger.info("Fetching videos...")
         videos_data, total = vector_db.fetch_videos(page=page, limit=limit)
         logger.debug(f"videos={videos_data}")
-        add_presigned_urls(videos_data, config["presigned_url_expiry"])
+        add_presigned_urls(videos_data, PRESIGNED_URL_EXPIRY)
 
         return build_success_response(
             data=videos_data, metadata={"total": total, "limit": limit, "page": page}

--- a/lambda/api_search_handler/build-package.sh
+++ b/lambda/api_search_handler/build-package.sh
@@ -15,9 +15,6 @@ uv pip install --target package/ --python-platform x86_64-unknown-linux-gnu --py
 # Copy Python source files to package directory
 cp *.py package/
 
-# Copy config JSON to package directory
-cp config.json package/
-
 # Create a zip file containing everything from the package directory at the zip root
 cd package
 zip -r ../${PACKAGE_NAME}.zip .

--- a/lambda/api_search_handler/config.json
+++ b/lambda/api_search_handler/config.json
@@ -1,4 +1,0 @@
-{
-  "secret_name": "kubrick_secret",
-  "query_media_file_size_limit": 6000000
-}

--- a/lambda/api_search_handler/config.json
+++ b/lambda/api_search_handler/config.json
@@ -1,4 +1,4 @@
 {
-  "secret_name": "KubrickEmbeddingTaskConsumerSecret",
+  "secret_name": "kubrick_secret",
   "query_media_file_size_limit": 6000000
 }

--- a/lambda/api_search_handler/search_controller.py
+++ b/lambda/api_search_handler/search_controller.py
@@ -72,12 +72,12 @@ class SearchController:
         self,
         embed_service: EmbedService,
         vector_db_service: VectorDBService,
-        config: Dict[str, Any],
+        query_media_file_size_limit: int = 6000000,
         logger: Logger = getLogger(),
     ):
         self.embed_service = embed_service
         self.vector_db_service = vector_db_service
-        self.config = config
+        self.query_media_file_size_limit = query_media_file_size_limit
         self.logger = logger
 
     def parse_lambda_event(self, event) -> SearchRequest:
@@ -137,9 +137,7 @@ class SearchController:
 
                     if part.filename:  # File field
                         file_size = part.size
-                        size_limit = self.config.get(
-                            "query_media_file_size_limit", 6000000
-                        )
+                        size_limit = self.query_media_file_size_limit
                         if file_size > size_limit:
                             raise SearchRequestError(
                                 f"Query media file size too large. Limit: {size_limit/1000} KB"

--- a/lambda/api_video_upload_link_handler/build-package.sh
+++ b/lambda/api_video_upload_link_handler/build-package.sh
@@ -15,9 +15,6 @@ uv pip install --target package/ --python-platform x86_64-unknown-linux-gnu --py
 # Copy Python source files to package directory
 cp *.py package/
 
-# Copy config JSON to package directory
-# cp config.json package/
-
 # Create a zip file containing everything from the package directory at the zip root
 cd package
 zip -r ../${PACKAGE_NAME}.zip .

--- a/lambda/db_bootstrap/build-package.sh
+++ b/lambda/db_bootstrap/build-package.sh
@@ -18,9 +18,6 @@ cp *.py package/
 # Copy schema SQL file to package directory
 cp schema.sql package/
 
-# Copy config JSON to package directory
-cp config.json package/
-
 # Create a zip file containing everything from the package directory at the zip root
 cd package
 zip -r ../${PACKAGE_NAME}.zip .

--- a/lambda/db_bootstrap/config.json
+++ b/lambda/db_bootstrap/config.json
@@ -1,3 +1,3 @@
 {
-  "secret_name": "kubrick_secrets"
+  "secret_name": "kubrick_secret"
 }

--- a/lambda/db_bootstrap/config.json
+++ b/lambda/db_bootstrap/config.json
@@ -1,3 +1,0 @@
-{
-  "secret_name": "kubrick_secret"
-}

--- a/lambda/db_bootstrap/lambda_function.py
+++ b/lambda/db_bootstrap/lambda_function.py
@@ -1,12 +1,15 @@
-from config import load_config, get_secret, setup_logging, get_db_config
+import os
+from config import get_secret, setup_logging, get_db_config
 import json
 import psycopg2
+
+# Environment variables
+SECRET_NAME = os.getenv("SECRET_NAME", "kubrick_secret")
 
 
 def lambda_handler(event, context):
     logger = setup_logging()
-    config = load_config()
-    SECRET = get_secret(config)
+    SECRET = get_secret(SECRET_NAME)
     DB_CONFIG = get_db_config(SECRET)
 
     try:

--- a/lambda/layers/config_layer/config.py
+++ b/lambda/layers/config_layer/config.py
@@ -60,7 +60,7 @@ def get_db_config(secret: Dict[str, Any]) -> Dict[str, Any]:
     Environment Variables:
         DB_HOST     : Database host, defaults to localhost
         DB_NAME     : Database name, defaults to kubrick
-        DB_USER     : Database user, defaults to postgres
+        DB_USERNAME : Database user, defaults to postgres
         DB_PASSWORD : Database password, defaults to password
         DB_PORT     : Database port, defaults to 5432
     """
@@ -68,7 +68,7 @@ def get_db_config(secret: Dict[str, Any]) -> Dict[str, Any]:
     return {
         "host": os.getenv("DB_HOST", "localhost"),
         "database": os.getenv("DB_NAME", "kubrick"),
-        "user": os.getenv("DB_USER", "postgres"),
+        "user": secret.get("DB_USERNAME", os.getenv("DB_USERNAME", "postgres")),
         "password": secret.get("DB_PASSWORD", os.getenv("DB_PASSWORD", "password")),
         "port": int(os.getenv("DB_PORT", 5432)),
     }

--- a/lambda/layers/config_layer/config.py
+++ b/lambda/layers/config_layer/config.py
@@ -8,29 +8,14 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def load_config(config_path: str = "config.json") -> Dict[str, Any]:
-    """Load configuration from JSON file."""
-    try:
-        logger.info("Loading config from config.json...")
-        with open(config_path) as f:
-            config = json.load(f)
-        required_keys = ["secret_name"]
-        missing_keys = [key for key in required_keys if key not in config]
-        if missing_keys:
-            raise ValueError(f"Missing required keys from config: {missing_keys}")
-        return config
-    except FileNotFoundError:
-        logger.error(f"Config file not found: {config_path}")
-        raise
 
-
-def get_secret(config: Dict[str, Any], key: str = "secret_name") -> Dict[str, Any]:
+def get_secret(secret_name: str = "kubrick_secret") -> Dict[str, Any]:
     """Retrieve secret from AWS Secrets Manager."""
 
     try:
         logger.info("Retrieving secret...")
         secretsmanager = boto3.client("secretsmanager")
-        sm_response = secretsmanager.get_secret_value(SecretId=config[key])
+        sm_response = secretsmanager.get_secret_value(SecretId=secret_name)
         return json.loads(sm_response["SecretString"])
     except Exception as e:
         logger.error(f"Failed to retrieve secret: {e}")

--- a/lambda/s3_delete_handler/build-package.sh
+++ b/lambda/s3_delete_handler/build-package.sh
@@ -15,9 +15,6 @@ uv pip install --target package/ --python-platform x86_64-unknown-linux-gnu --py
 # Copy Python source files to package directory
 cp *.py package/
 
-# Copy config JSON to package directory
-cp config.json package/
-
 # Create a zip file containing everything from the package directory at the zip root
 cd package
 zip -r ../${PACKAGE_NAME}.zip .

--- a/lambda/s3_delete_handler/config.json
+++ b/lambda/s3_delete_handler/config.json
@@ -1,3 +1,3 @@
 {
-  "secret_name": "KubrickEmbeddingTaskConsumerSecret"
+  "secret_name": "kubrick_secret"
 }

--- a/lambda/s3_delete_handler/config.json
+++ b/lambda/s3_delete_handler/config.json
@@ -1,3 +1,0 @@
-{
-  "secret_name": "kubrick_secret"
-}

--- a/lambda/s3_delete_handler/lambda_function.py
+++ b/lambda/s3_delete_handler/lambda_function.py
@@ -1,13 +1,16 @@
 import urllib.parse
-from config import load_config, get_secret, setup_logging, get_db_config
+import os
+from config import get_secret, setup_logging, get_db_config
 from vector_db_service import VectorDBService
 from utils import is_valid_video_file
+
+# Environment variables
+SECRET_NAME = os.getenv("SECRET_NAME", "kubrick_secret")
 
 
 def lambda_handler(event, context):
     logger = setup_logging()
-    config = load_config()
-    SECRET = get_secret(config)
+    SECRET = get_secret(SECRET_NAME)
     DB_CONFIG = get_db_config(SECRET)
 
     vector_db_service = VectorDBService(db_params=DB_CONFIG, logger=logger)

--- a/lambda/sqs_embedding_task_consumer/build-package.sh
+++ b/lambda/sqs_embedding_task_consumer/build-package.sh
@@ -15,9 +15,6 @@ uv pip install --target package/ --python-platform x86_64-unknown-linux-gnu --py
 # Copy Python source files to package directory
 cp *.py package/
 
-# Copy config JSON to package directory
-cp config.json package/
-
 # Create a zip file containing everything from the package directory at the zip root
 cd package
 zip -r ../${PACKAGE_NAME}.zip .

--- a/lambda/sqs_embedding_task_consumer/config.json
+++ b/lambda/sqs_embedding_task_consumer/config.json
@@ -1,3 +1,3 @@
 {
-  "secret_name": "KubrickEmbeddingTaskConsumerSecret"
+  "secret_name": "kubrick_secret"
 }

--- a/lambda/sqs_embedding_task_consumer/config.json
+++ b/lambda/sqs_embedding_task_consumer/config.json
@@ -1,3 +1,0 @@
-{
-  "secret_name": "kubrick_secret"
-}

--- a/lambda/sqs_embedding_task_consumer/lambda_function.py
+++ b/lambda/sqs_embedding_task_consumer/lambda_function.py
@@ -1,8 +1,11 @@
 import json
 import os
 from embed_service import EmbedService, VideoEmbeddingMetadata
-from config import load_config, get_secret, setup_logging, get_db_config
+from config import get_secret, setup_logging, get_db_config
 from vector_db_service import VectorDBService
+
+# Environment variables
+SECRET_NAME = os.getenv("SECRET_NAME", "kubrick_secret")
 
 
 def get_video_metadata(tl_metadata: VideoEmbeddingMetadata | None, message_body):
@@ -19,8 +22,7 @@ def get_video_metadata(tl_metadata: VideoEmbeddingMetadata | None, message_body)
 
 def lambda_handler(event, context):
     logger = setup_logging()
-    config = load_config()
-    SECRET = get_secret(config)
+    SECRET = get_secret(SECRET_NAME)
     DB_CONFIG = get_db_config(SECRET)
 
     embed_service = EmbedService(

--- a/lambda/sqs_embedding_task_producer/build-package.sh
+++ b/lambda/sqs_embedding_task_producer/build-package.sh
@@ -15,9 +15,6 @@ uv pip install --target package/ --python-platform x86_64-unknown-linux-gnu --py
 # Copy Python source files to package directory
 cp *.py package/
 
-# Copy config JSON to package directory
-cp config.json package/
-
 # Create a zip file containing everything from the package directory at the zip root
 cd package
 zip -r ../${PACKAGE_NAME}.zip .

--- a/lambda/sqs_embedding_task_producer/config.json
+++ b/lambda/sqs_embedding_task_producer/config.json
@@ -1,9 +1,0 @@
-{
-  "model_name": "Marengo-retrieval-2.7",
-  "video_embedding_scopes": ["clip", "video"],
-  "secret_name": "kubrick_secret",
-  "clip_length": 6,
-  "presigned_url_ttl": 600,
-  "file_check_retries": 2,
-  "file_check_delay_sec": 0.5
-}

--- a/lambda/sqs_embedding_task_producer/config.json
+++ b/lambda/sqs_embedding_task_producer/config.json
@@ -1,7 +1,7 @@
 {
   "model_name": "Marengo-retrieval-2.7",
   "video_embedding_scopes": ["clip", "video"],
-  "secret_name": "KubrickEmbeddingTaskConsumerSecret",
+  "secret_name": "kubrick_secret",
   "clip_length": 6,
   "presigned_url_ttl": 600,
   "file_check_retries": 2,

--- a/lambda/sqs_embedding_task_producer/lambda_function.py
+++ b/lambda/sqs_embedding_task_producer/lambda_function.py
@@ -106,8 +106,8 @@ def lambda_handler(event, context):
             s3,
             bucket,
             key,
-            config["file_check_retries"],
-            config["file_check_delay_sec"],
+            FILE_CHECK_RETRIES,
+            FILE_CHECK_DELAY_SEC,
             logger,
         ):
             raise FileNotFoundError(f"File s3://{bucket}/{key} not found after retries")
@@ -115,10 +115,10 @@ def lambda_handler(event, context):
         presigned_url = s3.generate_presigned_url(
             "get_object",
             Params={"Bucket": bucket, "Key": key},
-            ExpiresIn=config["presigned_url_ttl"],
+            ExpiresIn=PRESIGNED_URL_TTL,
         )
         logger.info(
-            f"Presigned URL generated (expires in {config['presigned_url_ttl']} seconds)"
+            f"Presigned URL generated (expires in {PRESIGNED_URL_TTL} seconds)"
         )
 
         task_id = embed_service.create_embedding_request(url=presigned_url).id

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -2,10 +2,11 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
-data "aws_secretsmanager_secret" "kubrick_secrets" {
+data "aws_secretsmanager_secret" "kubrick_secret" {
   name = var.secrets_manager_name
 }
 
-data "aws_secretsmanager_secret_version" "kubrick_secrets_version" {
-  secret_id = data.aws_secretsmanager_secret.kubrick_secrets.id
+data "aws_secretsmanager_secret_version" "kubrick_secret_version" {
+  secret_id = data.aws_secretsmanager_secret.kubrick_secret.id
 }
+

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -2,10 +2,22 @@ locals {
   region          = var.aws_region
   env             = "dev"
   secret          = jsondecode(data.aws_secretsmanager_secret_version.kubrick_secret_version.secret_string)
-  embedding_model = "Marengo-retrieval-2.7"
-  clip_length     = 6
-  min_similarity  = 0.2
-  page_limit      = 5
-  azs             = data.aws_availability_zones.available.names
+  
+  # Application configuration defaults
+  embedding_model                = "Marengo-retrieval-2.7"
+  clip_length                    = 6
+  min_similarity                 = 0.2
+  page_limit                     = 5
+  query_media_file_size_limit    = 6000000
+  default_task_limit             = 10
+  max_task_limit                 = 50
+  default_task_page              = 0
+  presigned_url_expiry           = 86400
+  presigned_url_ttl              = 600
+  file_check_retries             = 2
+  file_check_delay_sec           = 2.0
+  video_embedding_scopes         = ["clip", "video"]
+  
+  azs = data.aws_availability_zones.available.names
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,23 +1,23 @@
 locals {
-  region          = var.aws_region
-  env             = "dev"
-  secret          = jsondecode(data.aws_secretsmanager_secret_version.kubrick_secret_version.secret_string)
-  
+  region = var.aws_region
+  env    = "dev"
+  secret = jsondecode(data.aws_secretsmanager_secret_version.kubrick_secret_version.secret_string)
+
   # Application configuration defaults
-  embedding_model                = "Marengo-retrieval-2.7"
-  clip_length                    = 6
-  min_similarity                 = 0.2
-  page_limit                     = 5
-  query_media_file_size_limit    = 6000000
-  default_task_limit             = 10
-  max_task_limit                 = 50
-  default_task_page              = 0
-  presigned_url_expiry           = 86400
-  presigned_url_ttl              = 600
-  file_check_retries             = 2
-  file_check_delay_sec           = 2.0
-  video_embedding_scopes         = ["clip", "video"]
-  
+  embedding_model             = "Marengo-retrieval-2.7"
+  clip_length                 = 6
+  min_similarity              = 0.2
+  page_limit                  = 5
+  query_media_file_size_limit = 6000000
+  default_task_limit          = 10
+  max_task_limit              = 50
+  default_task_page           = 0
+  presigned_url_expiry        = 86400
+  presigned_url_ttl           = 600
+  file_check_retries          = 2
+  file_check_delay_sec        = 2.0
+  video_embedding_scopes      = ["clip", "video"]
+
   azs = data.aws_availability_zones.available.names
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,7 +1,7 @@
 locals {
   region          = var.aws_region
   env             = "dev"
-  secrets         = jsondecode(data.aws_secretsmanager_secret_version.kubrick_secrets_version.secret_string)
+  secret          = jsondecode(data.aws_secretsmanager_secret_version.kubrick_secret_version.secret_string)
   embedding_model = "Marengo-retrieval-2.7"
   clip_length     = 6
   min_similarity  = 0.2

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,7 +7,7 @@ module "vpc_network" {
 
 module "iam" {
   source                   = "./modules/iam"
-  secret_arn               = data.aws_secretsmanager_secret.kubrick_secrets.arn
+  secret_arn               = data.aws_secretsmanager_secret.kubrick_secret.arn
   environment              = local.env
   embedding_task_queue_arn = module.sqs.queue_arn
 }
@@ -19,7 +19,7 @@ module "s3" {
 # kubrick_sqs_embedding_task_producer_function
 # kubrick_s3_delete_handler_function
 module "s3_notifications" {
-  source = "./modules/s3_notifications"
+  source                      = "./modules/s3_notifications"
   bucket_id                   = module.s3.bucket_id
   create_lambda_function_arn  = module.lambda.kubrick_sqs_embedding_task_producer_arn
   create_lambda_function_name = module.lambda.kubrick_sqs_embedding_task_producer_function_name
@@ -32,8 +32,8 @@ module "s3_notifications" {
 
 module "rds" {
   source               = "./modules/rds"
-  db_username          = local.secrets.DB_USERNAME
-  db_password          = local.secrets.DB_PASSWORD
+  db_username          = local.secret.DB_USERNAME
+  db_password          = local.secret.DB_PASSWORD
   vpc_id               = module.vpc_network.vpc_id
   db_subnet_ids        = module.vpc_network.private_subnet_ids
   public_subnet_cidrs  = module.vpc_network.public_subnets_cidrs
@@ -51,8 +51,8 @@ module "lambda" {
   lambda_iam_sqs_embedding_task_producer_role_arn   = module.iam.sqs_embedding_task_producer_role_arn
   lambda_iam_sqs_embedding_task_consumer_role_arn   = module.iam.sqs_embedding_task_consumer_role_arn
   db_host                                           = module.rds.db_host
-  db_username                                       = local.secrets.DB_USERNAME
-  db_password                                       = local.secrets.DB_PASSWORD
+  db_username                                       = local.secret.DB_USERNAME
+  db_password                                       = local.secret.DB_PASSWORD
   embedding_model                                   = local.embedding_model
   min_similarity                                    = local.min_similarity
   page_limit                                        = local.page_limit
@@ -76,16 +76,16 @@ module "sqs" {
 }
 
 module "api_gateway" {
-  source                              = "./modules/api_gateway"
-  fetch_videos_lambda_invoke_arn      = module.lambda.kubrick_api_fetch_videos_handler_invoke_arn
-  search_lambda_invoke_arn            = module.lambda.kubrick_api_search_handler_invoke_arn
-  upload_link_lambda_invoke_arn       = module.lambda.kubrick_api_video_upload_link_handler_invoke_arn
-  fetch_tasks_lambda_invoke_arn       = module.lambda.kubrick_api_fetch_tasks_handler_invoke_arn
-  fetch_videos_lambda_function_name   = module.lambda.kubrick_api_fetch_videos_handler_function_name
-  search_lambda_function_name         = module.lambda.kubrick_api_search_handler_function_name
-  upload_link_lambda_function_name    = module.lambda.kubrick_api_video_upload_link_handler_function_name
-  fetch_tasks_lambda_function_name    = module.lambda.kubrick_api_fetch_tasks_handler_function_name
-  aws_region                          = local.region
+  source                            = "./modules/api_gateway"
+  fetch_videos_lambda_invoke_arn    = module.lambda.kubrick_api_fetch_videos_handler_invoke_arn
+  search_lambda_invoke_arn          = module.lambda.kubrick_api_search_handler_invoke_arn
+  upload_link_lambda_invoke_arn     = module.lambda.kubrick_api_video_upload_link_handler_invoke_arn
+  fetch_tasks_lambda_invoke_arn     = module.lambda.kubrick_api_fetch_tasks_handler_invoke_arn
+  fetch_videos_lambda_function_name = module.lambda.kubrick_api_fetch_videos_handler_function_name
+  search_lambda_function_name       = module.lambda.kubrick_api_search_handler_function_name
+  upload_link_lambda_function_name  = module.lambda.kubrick_api_video_upload_link_handler_function_name
+  fetch_tasks_lambda_function_name  = module.lambda.kubrick_api_fetch_tasks_handler_function_name
+  aws_region                        = local.region
 
   depends_on = [module.lambda]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,6 +57,15 @@ module "lambda" {
   min_similarity                                    = local.min_similarity
   page_limit                                        = local.page_limit
   clip_length                                       = local.clip_length
+  query_media_file_size_limit                       = local.query_media_file_size_limit
+  default_task_limit                                = local.default_task_limit
+  max_task_limit                                    = local.max_task_limit
+  default_task_page                                 = local.default_task_page
+  presigned_url_expiry                              = local.presigned_url_expiry
+  presigned_url_ttl                                 = local.presigned_url_ttl
+  file_check_retries                                = local.file_check_retries
+  file_check_delay_sec                              = local.file_check_delay_sec
+  video_embedding_scopes                            = local.video_embedding_scopes
   private_subnet_ids                                = module.vpc_network.private_subnet_ids
   vpc_id                                            = module.vpc_network.vpc_id
   s3_bucket_name                                    = module.s3.bucket_name

--- a/terraform/modules/iam/locals.tf
+++ b/terraform/modules/iam/locals.tf
@@ -34,14 +34,14 @@ locals {
 
   # IAM Roles and their policies
   lambda_role_policies = {
-    kubrick_db_bootstrap                  = ["lambda_basic_execution", "secrets_access", "lambda_vpc_access"]
-    kubrick_s3_delete_handler             = ["s3_full_access", "lambda_basic_execution", "secrets_access", "lambda_vpc_access"]
-    kubrick_api_search_handler            = ["s3_readonly_access", "lambda_basic_execution", "secrets_access", "lambda_vpc_access"]
-    kubrick_api_fetch_videos_handler      = ["s3_readonly_access", "lambda_basic_execution", "secrets_access", "lambda_vpc_access"]
-    kubrick_api_video_upload_link_handler = ["s3_full_access", "lambda_basic_execution", "lambda_vpc_access"]
-    kubrick_api_fetch_tasks_handler       = ["lambda_basic_execution", "secrets_access", "lambda_vpc_access"]
-    kubrick_sqs_embedding_task_producer   = ["s3_full_access", "lambda_basic_execution", "secrets_access", "sqs_full_access", "lambda_vpc_access"]
-    kubrick_sqs_embedding_task_consumer   = ["lambda_sqs_execution", "secrets_access", "lambda_vpc_access"]
+    kubrick_db_bootstrap                  = ["lambda_basic_execution", "lambda_vpc_access", "secrets_access"]
+    kubrick_s3_delete_handler             = ["lambda_basic_execution", "lambda_vpc_access", "secrets_access", "s3_full_access"]
+    kubrick_api_search_handler            = ["lambda_basic_execution", "lambda_vpc_access", "secrets_access", "s3_readonly_access"]
+    kubrick_api_fetch_videos_handler      = ["lambda_basic_execution", "lambda_vpc_access", "secrets_access", "s3_readonly_access"]
+    kubrick_api_video_upload_link_handler = ["lambda_basic_execution", "lambda_vpc_access", "s3_full_access"]
+    kubrick_api_fetch_tasks_handler       = ["lambda_basic_execution", "lambda_vpc_access", "secrets_access"]
+    kubrick_sqs_embedding_task_producer   = ["lambda_basic_execution", "lambda_vpc_access", "secrets_access", "s3_full_access", "sqs_full_access"]
+    kubrick_sqs_embedding_task_consumer   = ["lambda_basic_execution", "lambda_vpc_access", "secrets_access", "lambda_sqs_execution"]
   }
 
   # Merge managed + custom policy ARNs

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -70,7 +70,9 @@ resource "aws_lambda_function" "kubrick_db_bootstrap" {
 
   environment {
     variables = {
-      DB_HOST = var.db_host
+      DB_HOST     = var.db_host
+      SECRET_NAME = "kubrick_secret"
+      LOG_LEVEL   = "INFO"
     }
   }
 
@@ -119,13 +121,15 @@ resource "aws_lambda_function" "kubrick_api_search_handler" {
 
   environment {
     variables = {
-      DB_HOST                = var.db_host
-      DB_PASSWORD            = var.db_password
-      DEFAULT_CLIP_LENGTH    = var.clip_length
-      DEFAULT_MIN_SIMILARITY = var.min_similarity
-      DEFAULT_PAGE_LIMIT     = var.page_limit
-      EMBEDDING_MODEL_NAME   = var.embedding_model
-      LOG_LEVEL              = "INFO"
+      DB_HOST                         = var.db_host
+      DB_PASSWORD                     = var.db_password
+      DEFAULT_CLIP_LENGTH             = var.clip_length
+      DEFAULT_MIN_SIMILARITY          = var.min_similarity
+      DEFAULT_PAGE_LIMIT              = var.page_limit
+      EMBEDDING_MODEL_NAME            = var.embedding_model
+      QUERY_MEDIA_FILE_SIZE_LIMIT     = var.query_media_file_size_limit
+      SECRET_NAME                     = "kubrick_secret"
+      LOG_LEVEL                       = "INFO"
     }
   }
 
@@ -154,7 +158,9 @@ resource "aws_lambda_function" "kubrick_s3_delete_handler" {
 
   environment {
     variables = {
-      DB_HOST = var.db_host
+      DB_HOST     = var.db_host
+      SECRET_NAME = "kubrick_secret"
+      LOG_LEVEL   = "INFO"
     }
   }
 
@@ -184,8 +190,10 @@ resource "aws_lambda_function" "kubrick_api_fetch_videos_handler" {
 
   environment {
     variables = {
-      DB_HOST   = var.db_host
-      LOG_LEVEL = "INFO"
+      DB_HOST                = var.db_host
+      PRESIGNED_URL_EXPIRY   = var.presigned_url_expiry
+      SECRET_NAME            = "kubrick_secret"
+      LOG_LEVEL              = "INFO"
     }
   }
 
@@ -244,7 +252,12 @@ resource "aws_lambda_function" "kubrick_api_fetch_tasks_handler" {
 
   environment {
     variables = {
-      DB_HOST = var.db_host
+      DB_HOST            = var.db_host
+      DEFAULT_TASK_LIMIT = var.default_task_limit
+      MAX_TASK_LIMIT     = var.max_task_limit
+      DEFAULT_TASK_PAGE  = var.default_task_page
+      SECRET_NAME        = "kubrick_secret"
+      LOG_LEVEL          = "INFO"
     }
   }
 
@@ -275,10 +288,16 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_producer" {
   environment {
     variables = {
       # TODO: PGHOST is not consistent
-      DB_HOST              = var.db_host
-      DEFAULT_CLIP_LENGTH  = var.clip_length
-      EMBEDDING_MODEL_NAME = var.embedding_model
-      QUEUE_URL            = var.queue_url
+      DB_HOST                  = var.db_host
+      DEFAULT_CLIP_LENGTH      = var.clip_length
+      EMBEDDING_MODEL_NAME     = var.embedding_model
+      QUEUE_URL                = var.queue_url
+      PRESIGNED_URL_TTL        = var.presigned_url_ttl
+      FILE_CHECK_RETRIES       = var.file_check_retries
+      FILE_CHECK_DELAY_SEC     = var.file_check_delay_sec
+      VIDEO_EMBEDDING_SCOPES   = jsonencode(var.video_embedding_scopes)
+      SECRET_NAME              = "kubrick_secret"
+      LOG_LEVEL                = "INFO"
     }
   }
 
@@ -311,6 +330,8 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_consumer" {
     variables = {
       DB_HOST     = var.db_host
       DB_PASSWORD = var.db_password
+      SECRET_NAME = "kubrick_secret"
+      LOG_LEVEL   = "INFO"
     }
   }
 

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -127,15 +127,15 @@ resource "aws_lambda_function" "kubrick_api_search_handler" {
 
   environment {
     variables = {
-      DB_HOST                         = var.db_host
-      DB_PASSWORD                     = var.db_password
-      DEFAULT_CLIP_LENGTH             = var.clip_length
-      DEFAULT_MIN_SIMILARITY          = var.min_similarity
-      DEFAULT_PAGE_LIMIT              = var.page_limit
-      EMBEDDING_MODEL_NAME            = var.embedding_model
-      QUERY_MEDIA_FILE_SIZE_LIMIT     = var.query_media_file_size_limit
-      SECRET_NAME                     = "kubrick_secret"
-      LOG_LEVEL                       = "INFO"
+      DB_HOST                     = var.db_host
+      DB_PASSWORD                 = var.db_password
+      DEFAULT_CLIP_LENGTH         = var.clip_length
+      DEFAULT_MIN_SIMILARITY      = var.min_similarity
+      DEFAULT_PAGE_LIMIT          = var.page_limit
+      EMBEDDING_MODEL_NAME        = var.embedding_model
+      QUERY_MEDIA_FILE_SIZE_LIMIT = var.query_media_file_size_limit
+      SECRET_NAME                 = "kubrick_secret"
+      LOG_LEVEL                   = "INFO"
     }
   }
 
@@ -198,10 +198,10 @@ resource "aws_lambda_function" "kubrick_api_fetch_videos_handler" {
 
   environment {
     variables = {
-      DB_HOST                = var.db_host
-      PRESIGNED_URL_EXPIRY   = var.presigned_url_expiry
-      SECRET_NAME            = "kubrick_secret"
-      LOG_LEVEL              = "INFO"
+      DB_HOST              = var.db_host
+      PRESIGNED_URL_EXPIRY = var.presigned_url_expiry
+      SECRET_NAME          = "kubrick_secret"
+      LOG_LEVEL            = "INFO"
     }
   }
 
@@ -298,17 +298,16 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_producer" {
 
   environment {
     variables = {
-      # TODO: PGHOST is not consistent
-      DB_HOST                  = var.db_host
-      DEFAULT_CLIP_LENGTH      = var.clip_length
-      EMBEDDING_MODEL_NAME     = var.embedding_model
-      QUEUE_URL                = var.queue_url
-      PRESIGNED_URL_TTL        = var.presigned_url_ttl
-      FILE_CHECK_RETRIES       = var.file_check_retries
-      FILE_CHECK_DELAY_SEC     = var.file_check_delay_sec
-      VIDEO_EMBEDDING_SCOPES   = jsonencode(var.video_embedding_scopes)
-      SECRET_NAME              = "kubrick_secret"
-      LOG_LEVEL                = "INFO"
+      DB_HOST                = var.db_host
+      DEFAULT_CLIP_LENGTH    = var.clip_length
+      EMBEDDING_MODEL_NAME   = var.embedding_model
+      QUEUE_URL              = var.queue_url
+      PRESIGNED_URL_TTL      = var.presigned_url_ttl
+      FILE_CHECK_RETRIES     = var.file_check_retries
+      FILE_CHECK_DELAY_SEC   = var.file_check_delay_sec
+      VIDEO_EMBEDDING_SCOPES = jsonencode(var.video_embedding_scopes)
+      SECRET_NAME            = "kubrick_secret"
+      LOG_LEVEL              = "INFO"
     }
   }
 
@@ -347,7 +346,7 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_consumer" {
     }
   }
 
-  
+
 
   vpc_config {
     subnet_ids         = var.private_subnet_ids
@@ -364,6 +363,7 @@ resource "aws_lambda_event_source_mapping" "sqs_embedding_task_consumer_trigger"
   event_source_arn = var.queue_arn
   function_name    = aws_lambda_function.kubrick_sqs_embedding_task_consumer.arn
   batch_size       = 10
-  
+
   function_response_types = ["ReportBatchItemFailures"]
 }
+

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -4,6 +4,7 @@ resource "aws_lambda_layer_version" "vectordb_layer" {
   compatible_runtimes      = ["python3.13"]
   compatible_architectures = ["x86_64"]
   filename                 = "${local.base_path}/layers/vector_database_layer/package.zip"
+  source_code_hash         = filebase64sha256("${local.base_path}/layers/vector_database_layer/package.zip")
   description              = "Module for interacting with the PostgreSQL vector database"
 
   depends_on = [null_resource.layer_build_vectordb]
@@ -14,6 +15,7 @@ resource "aws_lambda_layer_version" "embed_layer" {
   compatible_runtimes      = ["python3.13"]
   compatible_architectures = ["x86_64"]
   filename                 = "${local.base_path}/layers/embed_service_layer/package.zip"
+  source_code_hash         = filebase64sha256("${local.base_path}/layers/embed_service_layer/package.zip")
   description              = "Multi-modal embedding extraction and management module using TwelveLabs API."
 
   depends_on = [null_resource.layer_build_embed]
@@ -24,6 +26,7 @@ resource "aws_lambda_layer_version" "config_layer" {
   compatible_runtimes      = ["python3.13"]
   compatible_architectures = ["x86_64"]
   filename                 = "${local.base_path}/layers/config_layer/package.zip"
+  source_code_hash         = filebase64sha256("${local.base_path}/layers/config_layer/package.zip")
   description              = "Configuration management module for secrets and database settings."
 
   depends_on = [null_resource.layer_build_config]
@@ -34,6 +37,7 @@ resource "aws_lambda_layer_version" "utils_layer" {
   compatible_runtimes      = ["python3.13"]
   compatible_architectures = ["x86_64"]
   filename                 = "${local.base_path}/layers/response_utils_layer/package.zip"
+  source_code_hash         = filebase64sha256("${local.base_path}/layers/response_utils_layer/package.zip")
   description              = "Utility module for error handling, S3 presigned URL generation, and API response construction."
 
   depends_on = [null_resource.layer_build_utils]
@@ -58,11 +62,12 @@ resource "aws_security_group" "lambda_private_egress_all_sg" {
 
 # kubrick_db_bootstrap
 resource "aws_lambda_function" "kubrick_db_bootstrap" {
-  function_name = "kubrick_db_bootstrap"
-  role          = var.lambda_iam_db_bootstrap_role_arn
-  runtime       = "python3.13"
-  handler       = "lambda_function.lambda_handler"
-  filename      = "${local.base_path}/db_bootstrap/package.zip"
+  function_name    = "kubrick_db_bootstrap"
+  role             = var.lambda_iam_db_bootstrap_role_arn
+  runtime          = "python3.13"
+  handler          = "lambda_function.lambda_handler"
+  filename         = "${local.base_path}/db_bootstrap/package.zip"
+  source_code_hash = filebase64sha256("${local.base_path}/db_bootstrap/package.zip")
 
   layers = [
     aws_lambda_layer_version.config_layer.arn,
@@ -106,11 +111,12 @@ resource "null_resource" "invoke_db_bootstrap" {
 
 # kubrick_api_search_handler
 resource "aws_lambda_function" "kubrick_api_search_handler" {
-  function_name = "kubrick_api_search_handler"
-  role          = var.lambda_iam_api_search_handler_role_arn
-  runtime       = "python3.13"
-  handler       = "lambda_function.lambda_handler"
-  filename      = "${local.base_path}/api_search_handler/package.zip"
+  function_name    = "kubrick_api_search_handler"
+  role             = var.lambda_iam_api_search_handler_role_arn
+  runtime          = "python3.13"
+  handler          = "lambda_function.lambda_handler"
+  filename         = "${local.base_path}/api_search_handler/package.zip"
+  source_code_hash = filebase64sha256("${local.base_path}/api_search_handler/package.zip")
 
   layers = [
     aws_lambda_layer_version.vectordb_layer.arn,
@@ -145,11 +151,12 @@ resource "aws_lambda_function" "kubrick_api_search_handler" {
 
 # kubrick_s3_delete_handler
 resource "aws_lambda_function" "kubrick_s3_delete_handler" {
-  function_name = "kubrick_s3_delete_handler"
-  role          = var.lambda_iam_s3_delete_handler_role_arn
-  runtime       = "python3.13"
-  handler       = "lambda_function.lambda_handler"
-  filename      = "${local.base_path}/s3_delete_handler/package.zip"
+  function_name    = "kubrick_s3_delete_handler"
+  role             = var.lambda_iam_s3_delete_handler_role_arn
+  runtime          = "python3.13"
+  handler          = "lambda_function.lambda_handler"
+  filename         = "${local.base_path}/s3_delete_handler/package.zip"
+  source_code_hash = filebase64sha256("${local.base_path}/s3_delete_handler/package.zip")
 
   layers = [
     aws_lambda_layer_version.vectordb_layer.arn,
@@ -176,11 +183,12 @@ resource "aws_lambda_function" "kubrick_s3_delete_handler" {
 
 # kubrick_api_fetch_videos_handler
 resource "aws_lambda_function" "kubrick_api_fetch_videos_handler" {
-  function_name = "kubrick_api_fetch_videos_handler"
-  role          = var.lambda_iam_api_fetch_videos_handler_role_arn
-  runtime       = "python3.13"
-  handler       = "lambda_function.lambda_handler"
-  filename      = "${local.base_path}/api_fetch_videos_handler/package.zip"
+  function_name    = "kubrick_api_fetch_videos_handler"
+  role             = var.lambda_iam_api_fetch_videos_handler_role_arn
+  runtime          = "python3.13"
+  handler          = "lambda_function.lambda_handler"
+  filename         = "${local.base_path}/api_fetch_videos_handler/package.zip"
+  source_code_hash = filebase64sha256("${local.base_path}/api_fetch_videos_handler/package.zip")
 
   layers = [
     aws_lambda_layer_version.vectordb_layer.arn,
@@ -209,11 +217,12 @@ resource "aws_lambda_function" "kubrick_api_fetch_videos_handler" {
 
 # kubrick_api_video_upload_link_handler
 resource "aws_lambda_function" "kubrick_api_video_upload_link_handler" {
-  function_name = "kubrick_api_video_upload_link_handler"
-  role          = var.lambda_iam_api_video_upload_link_handler_role_arn
-  runtime       = "python3.13"
-  handler       = "lambda_function.lambda_handler"
-  filename      = "${local.base_path}/api_video_upload_link_handler/package.zip"
+  function_name    = "kubrick_api_video_upload_link_handler"
+  role             = var.lambda_iam_api_video_upload_link_handler_role_arn
+  runtime          = "python3.13"
+  handler          = "lambda_function.lambda_handler"
+  filename         = "${local.base_path}/api_video_upload_link_handler/package.zip"
+  source_code_hash = filebase64sha256("${local.base_path}/api_video_upload_link_handler/package.zip")
 
   layers = [
     aws_lambda_layer_version.utils_layer.arn,
@@ -238,11 +247,12 @@ resource "aws_lambda_function" "kubrick_api_video_upload_link_handler" {
 
 # kubrick_api_fetch_tasks_handler
 resource "aws_lambda_function" "kubrick_api_fetch_tasks_handler" {
-  function_name = "kubrick_api_fetch_tasks_handler"
-  role          = var.lambda_iam_api_fetch_tasks_handler_role_arn
-  runtime       = "python3.13"
-  handler       = "lambda_function.lambda_handler"
-  filename      = "${local.base_path}/api_fetch_tasks_handler/package.zip"
+  function_name    = "kubrick_api_fetch_tasks_handler"
+  role             = var.lambda_iam_api_fetch_tasks_handler_role_arn
+  runtime          = "python3.13"
+  handler          = "lambda_function.lambda_handler"
+  filename         = "${local.base_path}/api_fetch_tasks_handler/package.zip"
+  source_code_hash = filebase64sha256("${local.base_path}/api_fetch_tasks_handler/package.zip")
 
   layers = [
     aws_lambda_layer_version.vectordb_layer.arn,
@@ -273,11 +283,12 @@ resource "aws_lambda_function" "kubrick_api_fetch_tasks_handler" {
 
 # kubrick_sqs_embedding_task_producer
 resource "aws_lambda_function" "kubrick_sqs_embedding_task_producer" {
-  function_name = "kubrick_sqs_embedding_task_producer"
-  role          = var.lambda_iam_sqs_embedding_task_producer_role_arn
-  runtime       = "python3.13"
-  handler       = "lambda_function.lambda_handler"
-  filename      = "${local.base_path}/sqs_embedding_task_producer/package.zip"
+  function_name    = "kubrick_sqs_embedding_task_producer"
+  role             = var.lambda_iam_sqs_embedding_task_producer_role_arn
+  runtime          = "python3.13"
+  handler          = "lambda_function.lambda_handler"
+  filename         = "${local.base_path}/sqs_embedding_task_producer/package.zip"
+  source_code_hash = filebase64sha256("${local.base_path}/sqs_embedding_task_producer/package.zip")
 
   layers = [
     aws_lambda_layer_version.vectordb_layer.arn,
@@ -313,11 +324,12 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_producer" {
 
 # kubrick_sqs_embedding_task_consumer
 resource "aws_lambda_function" "kubrick_sqs_embedding_task_consumer" {
-  function_name = "kubrick_sqs_embedding_task_consumer"
-  role          = var.lambda_iam_sqs_embedding_task_consumer_role_arn
-  runtime       = "python3.13"
-  handler       = "lambda_function.lambda_handler"
-  filename      = "${local.base_path}/sqs_embedding_task_consumer/package.zip"
+  function_name    = "kubrick_sqs_embedding_task_consumer"
+  role             = var.lambda_iam_sqs_embedding_task_consumer_role_arn
+  runtime          = "python3.13"
+  handler          = "lambda_function.lambda_handler"
+  filename         = "${local.base_path}/sqs_embedding_task_consumer/package.zip"
+  source_code_hash = filebase64sha256("${local.base_path}/sqs_embedding_task_consumer/package.zip")
 
   layers = [
     aws_lambda_layer_version.vectordb_layer.arn,

--- a/terraform/modules/lambda/provisioners.tf
+++ b/terraform/modules/lambda/provisioners.tf
@@ -55,7 +55,6 @@ resource "null_resource" "layer_build_utils" {
 resource "null_resource" "lambda_build_db_bootstrap" {
   triggers = {
     source_hash    = filemd5("${local.base_path}/db_bootstrap/lambda_function.py")
-    config_hash    = filemd5("${local.base_path}/db_bootstrap/config.json")
     deps_hash      = filemd5("${local.base_path}/db_bootstrap/pyproject.toml")
     schema_hash    = filemd5("${local.base_path}/db_bootstrap/schema.sql")
     package_exists = fileexists("${local.base_path}/db_bootstrap/package.zip")
@@ -72,7 +71,6 @@ resource "null_resource" "lambda_build_api_search_handler" {
     source_hash     = filemd5("${local.base_path}/api_search_handler/lambda_function.py")
     controller_hash = filemd5("${local.base_path}/api_search_handler/search_controller.py")
     errors_hash     = filemd5("${local.base_path}/api_search_handler/search_errors.py")
-    config_hash     = filemd5("${local.base_path}/api_search_handler/config.json")
     deps_hash       = filemd5("${local.base_path}/api_search_handler/pyproject.toml")
     package_exists  = fileexists("${local.base_path}/api_search_handler/package.zip")
   }
@@ -87,7 +85,6 @@ resource "null_resource" "lambda_build_s3_delete_handler" {
   triggers = {
     source_hash    = filemd5("${local.base_path}/s3_delete_handler/lambda_function.py")
     utils_hash     = filemd5("${local.base_path}/s3_delete_handler/utils.py")
-    config_hash    = filemd5("${local.base_path}/s3_delete_handler/config.json")
     deps_hash      = filemd5("${local.base_path}/s3_delete_handler/pyproject.toml")
     package_exists = fileexists("${local.base_path}/s3_delete_handler/package.zip")
   }
@@ -101,7 +98,6 @@ resource "null_resource" "lambda_build_s3_delete_handler" {
 resource "null_resource" "lambda_build_api_fetch_videos_handler" {
   triggers = {
     source_hash    = filemd5("${local.base_path}/api_fetch_videos_handler/lambda_function.py")
-    config_hash    = filemd5("${local.base_path}/api_fetch_videos_handler/config.json")
     deps_hash      = filemd5("${local.base_path}/api_fetch_videos_handler/pyproject.toml")
     package_exists = fileexists("${local.base_path}/api_fetch_videos_handler/package.zip")
   }
@@ -128,7 +124,6 @@ resource "null_resource" "lambda_build_api_video_upload_link_handler" {
 resource "null_resource" "lambda_build_api_fetch_tasks_handler" {
   triggers = {
     source_hash    = filemd5("${local.base_path}/api_fetch_tasks_handler/lambda_function.py")
-    config_hash    = filemd5("${local.base_path}/api_fetch_tasks_handler/config.json")
     deps_hash      = filemd5("${local.base_path}/api_fetch_tasks_handler/pyproject.toml")
     package_exists = fileexists("${local.base_path}/api_fetch_tasks_handler/package.zip")
   }
@@ -143,7 +138,6 @@ resource "null_resource" "lambda_build_sqs_embedding_task_producer" {
   triggers = {
     source_hash    = filemd5("${local.base_path}/sqs_embedding_task_producer/lambda_function.py")
     utils_hash     = filemd5("${local.base_path}/sqs_embedding_task_producer/utils.py")
-    config_hash    = filemd5("${local.base_path}/sqs_embedding_task_producer/config.json")
     deps_hash      = filemd5("${local.base_path}/sqs_embedding_task_producer/pyproject.toml")
     package_exists = fileexists("${local.base_path}/sqs_embedding_task_producer/package.zip")
   }
@@ -157,7 +151,6 @@ resource "null_resource" "lambda_build_sqs_embedding_task_producer" {
 resource "null_resource" "lambda_build_sqs_embedding_task_consumer" {
   triggers = {
     source_hash    = filemd5("${local.base_path}/sqs_embedding_task_consumer/lambda_function.py")
-    config_hash    = filemd5("${local.base_path}/sqs_embedding_task_consumer/config.json")
     deps_hash      = filemd5("${local.base_path}/sqs_embedding_task_consumer/pyproject.toml")
     package_exists = fileexists("${local.base_path}/sqs_embedding_task_consumer/package.zip")
   }
@@ -167,3 +160,4 @@ resource "null_resource" "lambda_build_sqs_embedding_task_consumer" {
     working_dir = "${local.base_path}/sqs_embedding_task_consumer"
   }
 }
+

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -148,3 +148,4 @@ variable "queue_arn" {
   description = "ARN of the SQS queue to trigger the embedding task consumer"
   type        = string
 }
+

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -33,6 +33,51 @@ variable "embedding_model" {
   type        = string
 }
 
+variable "query_media_file_size_limit" {
+  description = "Maximum file size for media queries"
+  type        = number
+}
+
+variable "default_task_limit" {
+  description = "Default limit for task queries"
+  type        = number
+}
+
+variable "max_task_limit" {
+  description = "Maximum limit for task queries"
+  type        = number
+}
+
+variable "default_task_page" {
+  description = "Default page number for task queries"
+  type        = number
+}
+
+variable "presigned_url_expiry" {
+  description = "Expiry time for presigned URLs in seconds"
+  type        = number
+}
+
+variable "presigned_url_ttl" {
+  description = "TTL for presigned URLs in seconds"
+  type        = number
+}
+
+variable "file_check_retries" {
+  description = "Number of retries for file checks"
+  type        = number
+}
+
+variable "file_check_delay_sec" {
+  description = "Delay between file check retries in seconds"
+  type        = number
+}
+
+variable "video_embedding_scopes" {
+  description = "Scopes for video embeddings"
+  type        = list(string)
+}
+
 variable "private_subnet_ids" {
   description = "VPC private subnet ids"
   type        = list(string)

--- a/terraform/output.json
+++ b/terraform/output.json
@@ -1,1 +1,0 @@
-{"statusCode": 200, "body": "\"Database initialization SQL script executed successfully.\""}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }

--- a/terraform/response.json
+++ b/terraform/response.json
@@ -1,1 +1,0 @@
-{"statusCode": 200, "body": "\"Database initialization SQL script executed successfully.\""}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -4,5 +4,5 @@
 # AWS Region - Update to match where your secrets and resources should be deployed
 aws_region = "ap-northeast-2"  # or us-east-1, us-west-2, etc.
 
-# Secrets Manager - Name of your secret containing API keys and RDS credentials  
-secrets_manager_name = "kubrick_secrets"
+# Secrets Manager - Name of your secret containing API keys and RDS credentials
+secrets_manager_name = "kubrick_secret"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,6 @@ variable "aws_region" {
 variable "secrets_manager_name" {
   description = "The name of the AWS Secrets Manager secret containing API keys and RDS credentials"
   type        = string
-  default     = "kubrick_secrets"
-  # default     = "KubrickEmbeddingTaskConsumerSecret" ## Changed to try to make testing work, delete this
+  default     = "kubrick_secret"
 }
 


### PR DESCRIPTION
- Updated secret structure: Changed secret format from nested object structure
  to flat key-value pairs (DB_USERNAME, DB_PASSWORD, TWELVELABS_API_KEY)
- Standardized secret name to `kubrick_secret`
- Removed config.json files across all Lambda functions and build scripts, we
  are now using environment variables for configuration and AWS Secrets Manager
  for sensitive data
- Converted all configuration parameters (clip length, file size limits, retry
  counts, etc.) to environment variables with defaults.
- Database configuration: Consolidated database username reference to consistent
  DB_USERNAME
- Updated README with new secret creation format
- Added Prettier configuration file for consistent code formatting
- Modified terraform lambda resources to include `source_code_hash`, which allows terraform to detect changes to the `package.zip` source files
- Modified terraform code to use new secret structure and pass configuration via
  environment variables to Lambda functions
- Modified terraform aws policy for consumer lambda to allow it to create a cloudwatch log group

