### PR TITLE
Api gateway url problem

### DIFF
--- a/playground/src/hooks/useKubrickAPI.ts
+++ b/playground/src/hooks/useKubrickAPI.ts
@@ -14,7 +14,7 @@ import {
 } from "@/types";
 
 // TODO: Move to config?
-const API_BASE = "https://xt30znkfhh.execute-api.us-east-1.amazonaws.com/dev";
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://127.0.0.1:5000";
 
 const search = async (params: SearchParams): Promise<Array<SearchResult>> => {
   const formData = new FormData();

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,12 +12,13 @@ module "iam" {
   embedding_task_queue_arn = module.sqs.queue_arn
 }
 
+# Public S3 bucket depends on API_Gateway
 module "s3" {
   source = "./modules/s3"
+
+  api_gateway_write_done = module.api_gateway.null_resource_write_api_url_to_env
 }
 
-# kubrick_sqs_embedding_task_producer_function
-# kubrick_s3_delete_handler_function
 module "s3_notifications" {
   source                      = "./modules/s3_notifications"
   bucket_id                   = module.s3.bucket_id
@@ -42,6 +43,7 @@ module "rds" {
 
 module "lambda" {
   source                                            = "./modules/lambda"
+
   aws_region                                        = local.region
   lambda_iam_db_bootstrap_role_arn                  = module.iam.db_bootstrap_role_arn
   lambda_iam_s3_delete_handler_role_arn             = module.iam.s3_delete_handler_role_arn

--- a/terraform/modules/api_gateway/locals.tf
+++ b/terraform/modules/api_gateway/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  api_gateway_url = "https://${aws_api_gateway_rest_api.api.id}.execute-api.${var.aws_region}.amazonaws.com/${var.stage_name}"
+}

--- a/terraform/modules/api_gateway/main.tf
+++ b/terraform/modules/api_gateway/main.tf
@@ -430,20 +430,6 @@ resource "aws_api_gateway_stage" "api_stage" {
 }
 
 # Working version without npm install
-resource "null_resource" "write_api_url_to_env" {
-  triggers = {
-    api_url = local.api_gateway_url
-  }
-
-  provisioner "local-exec" {
-    command = <<EOT
-echo "NEXT_PUBLIC_API_BASE=${self.triggers.api_url}" > ${path.root}/../playground/.env
-EOT
-  }
-
-  depends_on = [aws_api_gateway_stage.api_stage]
-}
-
 # resource "null_resource" "write_api_url_to_env" {
 #   triggers = {
 #     api_url = local.api_gateway_url
@@ -451,15 +437,29 @@ EOT
 
 #   provisioner "local-exec" {
 #     command = <<EOT
-# bash -c '
-# set -e
 # echo "NEXT_PUBLIC_API_BASE=${self.triggers.api_url}" > ${path.root}/../playground/.env
-# cd ${path.root}/../playground
-# npm install
-# npm run build
-# '
 # EOT
 #   }
 
 #   depends_on = [aws_api_gateway_stage.api_stage]
 # }
+
+resource "null_resource" "write_api_url_to_env" {
+  triggers = {
+    api_url = local.api_gateway_url
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+bash -c '
+set -e
+echo "NEXT_PUBLIC_API_BASE=${self.triggers.api_url}" > ${path.root}/../playground/.env
+cd ${path.root}/../playground
+npm install
+npm run build
+'
+EOT
+  }
+
+  depends_on = [aws_api_gateway_stage.api_stage]
+}

--- a/terraform/modules/api_gateway/main.tf
+++ b/terraform/modules/api_gateway/main.tf
@@ -428,3 +428,38 @@ resource "aws_api_gateway_stage" "api_stage" {
   rest_api_id   = aws_api_gateway_rest_api.api.id
   stage_name    = var.stage_name
 }
+
+# Working version without npm install
+resource "null_resource" "write_api_url_to_env" {
+  triggers = {
+    api_url = local.api_gateway_url
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+echo "NEXT_PUBLIC_API_BASE=${self.triggers.api_url}" > ${path.root}/../playground/.env
+EOT
+  }
+
+  depends_on = [aws_api_gateway_stage.api_stage]
+}
+
+# resource "null_resource" "write_api_url_to_env" {
+#   triggers = {
+#     api_url = local.api_gateway_url
+#   }
+
+#   provisioner "local-exec" {
+#     command = <<EOT
+# bash -c '
+# set -e
+# echo "NEXT_PUBLIC_API_BASE=${self.triggers.api_url}" > ${path.root}/../playground/.env
+# cd ${path.root}/../playground
+# npm install
+# npm run build
+# '
+# EOT
+#   }
+
+#   depends_on = [aws_api_gateway_stage.api_stage]
+# }

--- a/terraform/modules/api_gateway/outputs.tf
+++ b/terraform/modules/api_gateway/outputs.tf
@@ -42,3 +42,8 @@ output "api_gateway_arn" {
   description = "The ARN of the API Gateway REST API"
   value       = aws_api_gateway_rest_api.api.arn
 }
+
+output "api_gateway_url" {
+  description = "Base URL for the API Gateway"
+  value       = "https://${aws_api_gateway_rest_api.api.id}.execute-api.${var.aws_region}.amazonaws.com/${var.stage_name}"
+}

--- a/terraform/modules/api_gateway/outputs.tf
+++ b/terraform/modules/api_gateway/outputs.tf
@@ -47,3 +47,7 @@ output "api_gateway_url" {
   description = "Base URL for the API Gateway"
   value       = "https://${aws_api_gateway_rest_api.api.id}.execute-api.${var.aws_region}.amazonaws.com/${var.stage_name}"
 }
+
+output "null_resource_write_api_url_to_env" {
+  value = null_resource.write_api_url_to_env
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -109,3 +109,26 @@ resource "aws_s3_bucket_website_configuration" "kubrick_playground_bucket" {
     key = "index.html"
   }
 }
+
+
+resource "null_resource" "upload_static_site" {
+  depends_on = [
+    aws_s3_bucket_website_configuration.kubrick_playground_bucket,
+    var.api_gateway_write_done
+  ]
+
+  triggers = {
+    bucket_name = aws_s3_bucket.kubrick_playground_bucket.bucket
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+bash -c '
+set -e
+cd ${path.root}/../playground
+npm run build
+aws s3 sync out/ s3://${self.triggers.bucket_name} --delete
+'
+EOT
+  }
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -53,6 +53,8 @@ resource "aws_s3_bucket_policy" "kubrick_video_upload_bucket_policy" {
       }
     ]
   })
+
+  depends_on = [aws_s3_bucket_public_access_block.kubrick_video_upload_bucket]
 }
 
 # Public s3 bucket that hosts the playground frontend static files

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -20,3 +20,11 @@ output "kubrick_video_upload_bucket_name" {
 output "kubrick_playground_bucket_name" {
   value = aws_s3_bucket.kubrick_playground_bucket.bucket
 }
+
+output "kubrick_playground_bucket_regional_domain_name" {
+  value = aws_s3_bucket.kubrick_playground_bucket.bucket_regional_domain_name
+}
+
+output "kubrick_playground_bucket_arn" {
+  value = aws_s3_bucket.kubrick_playground_bucket.arn
+}

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -1,7 +1,4 @@
-output "kubrick_playground_bucket_regional_domain_name" {
-  value = aws_s3_bucket.kubrick_playground_bucket.bucket_regional_domain_name
-}
-
-output "kubrick_playground_bucket_arn" {
-  value = aws_s3_bucket.kubrick_playground_bucket.arn
+variable "api_gateway_write_done" {
+  type = any
+  description = "Dependency on API Gateway write to .env"
 }


### PR DESCRIPTION
- API Gateway is inputted into .env within playground (it doesn't create .env though)
- The creation of public `kubrick_playground` runs `npm run build` and uploads /out files into the S3.