### PR TITLE
Add unique constraint to videos table

### DIFF
--- a/lambda/db_bootstrap/schema.sql
+++ b/lambda/db_bootstrap/schema.sql
@@ -23,6 +23,8 @@ CREATE TABLE IF NOT EXISTS videos (
   width INTEGER
 );
 
+CREATE UNIQUE INDEX unique_s3_object ON videos (s3_bucket, s3_key);
+
 -- Trigger for videos
 DROP TRIGGER IF EXISTS trg_update_videos_updated_at ON videos;
 CREATE TRIGGER trg_update_videos_updated_at


### PR DESCRIPTION
This PR includes:
- Add unique constraint in `schema.sql` so in the videos table a bucket/key pair cannot be added twice