### PR TITLE
Fix pre signed url

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,12 +3,14 @@
     "./lambda/layers/vector_database_layer/",
     "./lambda/layers/embed_service_layer/",
     "./lambda/layers/response_utils_layer/",
-    "./lambda/layers/config_layer/"
+    "./lambda/layers/config_layer/",
+    "./lambda/layers/s3_utils_layer/"
   ],
   "python.autoComplete.extraPaths": [
     "./lambda/layers/vector_database_layer/",
     "./lambda/layers/embed_service_layer/",
     "./lambda/layers/response_utils_layer/",
-    "./lambda/layers/config_layer/"
+    "./lambda/layers/config_layer/",
+    "./lambda/layers/s3_utils_layer/"
   ]
 }

--- a/lambda/api_video_upload_link_handler/lambda_function.py
+++ b/lambda/api_video_upload_link_handler/lambda_function.py
@@ -72,13 +72,14 @@ def lambda_handler(event, context):
         key = f"uploads/{uuid.uuid4()}/{filename}"
         expiration = int(os.environ.get("PRESIGNED_URL_EXPIRATION", 3600))
 
-        logger.info(
-            f"Generating presigned URL for bucket: {bucket}, key: {key}"
-        )
+        logger.info(f"Generating presigned URL for bucket: {bucket}, key: {key}")
 
         presigned_url = s3_utils.generate_presigned_url(
-            bucket=bucket, key=key, content_type="put_object",
-            expires_in=PRESIGNED_URL_TTL
+            bucket=bucket,
+            key=key,
+            client_method="put_object",
+            content_type=get_content_type(file_extension),
+            expires_in=PRESIGNED_URL_TTL,
         )
 
         logger.info("Presigned URL generated successfully")

--- a/lambda/api_video_upload_link_handler/lambda_function.py
+++ b/lambda/api_video_upload_link_handler/lambda_function.py
@@ -3,6 +3,7 @@ import os
 import boto3
 import uuid
 from response_utils import ErrorCode, build_success_response, build_error_response
+import s3_utils
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)

--- a/lambda/api_video_upload_link_handler/pyproject.toml
+++ b/lambda/api_video_upload_link_handler/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Lambda Function to handle generating presigned URLs for S3 video upload"
 readme = ""
 requires-python = ">=3.13"
-dependencies = ["boto3>=1.39.14"]
+dependencies = []
 
 [tool.pyright]
 extraPaths = ["../layers/response_utils_layer/"]

--- a/lambda/layers/s3_utils_layer/s3_utils.py
+++ b/lambda/layers/s3_utils_layer/s3_utils.py
@@ -62,16 +62,23 @@ def wait_for_file(
 
 
 def generate_presigned_url(
-    bucket: str, key: str, expires_in: int = 3600, client_method="get_object"
+    bucket: str,
+    key: str,
+    content_type: str = None,
+    expires_in: int = 3600,
+    client_method="get_object",
 ) -> str:
     return asyncio.run(
-        generate_presigned_url_async(bucket, key, expires_in, client_method)
+        generate_presigned_url_async(
+            bucket, key, content_type, expires_in, client_method
+        )
     )
 
 
 async def generate_presigned_url_async(
     bucket: str,
     key: str,
+    content_type: str = None,
     expires_in: int = 3600,
     client_method="get_object",
     session=aioboto3.Session(),
@@ -82,7 +89,11 @@ async def generate_presigned_url_async(
         try:
             url = await s3_client.generate_presigned_url(
                 ClientMethod=client_method,
-                Params={"Bucket": bucket, "Key": key},
+                Params=(
+                    {"Bucket": bucket, "Key": key, "ContentType": content_type}
+                    if content_type
+                    else {"Bucket": bucket, "Key": key}
+                ),
                 ExpiresIn=expires_in,
             )
 

--- a/lambda/layers/s3_utils_layer/s3_utils.py
+++ b/lambda/layers/s3_utils_layer/s3_utils.py
@@ -87,13 +87,14 @@ async def generate_presigned_url_async(
         "s3", region_name=S3_REGION, config=S3_CLIENT_CONFIG
     ) as s3_client:  # type: ignore (type error in aioboto3 library)
         try:
+            params = {"Bucket": bucket, "Key": key}
+
+            if content_type:
+                params["ContentType"] = content_type
+
             url = await s3_client.generate_presigned_url(
                 ClientMethod=client_method,
-                Params=(
-                    {"Bucket": bucket, "Key": key, "ContentType": content_type}
-                    if content_type
-                    else {"Bucket": bucket, "Key": key}
-                ),
+                Params=params,
                 ExpiresIn=expires_in,
             )
 

--- a/lambda/sqs_embedding_task_producer/lambda_function.py
+++ b/lambda/sqs_embedding_task_producer/lambda_function.py
@@ -19,7 +19,6 @@ VIDEO_EMBEDDING_SCOPES = json.loads(
     os.getenv("VIDEO_EMBEDDING_SCOPES", '["clip", "video"]')
 )
 QUEUE_URL = os.environ["QUEUE_URL"]
-S3_REGION = os.getenv("S3_REGION", "us-east-1")
 
 sqs = boto3.client("sqs")
 logger = setup_logging()

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -230,8 +230,8 @@ resource "aws_lambda_function" "kubrick_api_video_upload_link_handler" {
 
   environment {
     variables = {
-      PRESIGNED_URL_EXPIRATION = 900 # This is a magic number, could prob go to locals
-      S3_BUCKET_NAME           = var.s3_bucket_name
+      PRESIGNED_URL_TTL = var.presigned_url_ttl
+      S3_BUCKET_NAME    = var.s3_bucket_name
     }
   }
 
@@ -297,7 +297,6 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_producer" {
 
   environment {
     variables = {
-      S3_REGION              = var.aws_region
       DB_HOST                = var.db_host
       DEFAULT_CLIP_LENGTH    = var.clip_length
       EMBEDDING_MODEL_NAME   = var.embedding_model


### PR DESCRIPTION
This PR includes:
- The api_video_upload_link_handler lambda now uses the generate_presigned_url from s3 utils layer
- Remove unused env variables from terraform lambdas