### PR TITLE
Fix lambda sqs timeout

### DIFF
--- a/lambda/api_video_upload_link_handler/pyproject.toml
+++ b/lambda/api_video_upload_link_handler/pyproject.toml
@@ -7,4 +7,4 @@ requires-python = ">=3.13"
 dependencies = []
 
 [tool.pyright]
-extraPaths = ["../layers/response_utils_layer/"]
+extraPaths = ["../layers/response_utils_layer/", "../layers/s3_utils_layer/"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,11 @@
 module "secrets_manager" {
-  source              = "./modules/secrets_manager"
-  name                = var.secrets_manager_name
-  description         = "Secret store for Kubrick application"
-  environment         = local.env
-  db_username         = var.db_username
-  db_password         = var.db_password
-  twelvelabs_api_key  = var.twelvelabs_api_key
+  source             = "./modules/secrets_manager"
+  name               = var.secrets_manager_name
+  description        = "Secret store for Kubrick application"
+  environment        = local.env
+  db_username        = var.db_username
+  db_password        = var.db_password
+  twelvelabs_api_key = var.twelvelabs_api_key
 }
 
 module "vpc_network" {
@@ -55,7 +55,7 @@ module "rds" {
 }
 
 module "lambda" {
-  source                                            = "./modules/lambda"
+  source = "./modules/lambda"
 
   aws_region                                        = local.region
   lambda_iam_db_bootstrap_role_arn                  = module.iam.db_bootstrap_role_arn

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -359,7 +359,7 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_consumer" {
 resource "aws_lambda_event_source_mapping" "sqs_embedding_task_consumer_trigger" {
   event_source_arn = var.queue_arn
   function_name    = aws_lambda_function.kubrick_sqs_embedding_task_consumer.arn
-  batch_size       = 10
+  batch_size       = 1
 
   function_response_types = ["ReportBatchItemFailures"]
 }

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -351,7 +351,7 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_consumer" {
     security_group_ids = [aws_security_group.lambda_private_egress_all_sg.id]
   }
 
-  timeout = 30 # 30s timeout for embedding tasks
+  timeout = 25 # 25s timeout for embedding tasks
 
 }
 

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -344,8 +344,6 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_consumer" {
     }
   }
 
-
-
   vpc_config {
     subnet_ids         = var.private_subnet_ids
     security_group_ids = [aws_security_group.lambda_private_egress_all_sg.id]

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -334,7 +334,7 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_consumer" {
     aws_lambda_layer_version.config_layer.arn,
   ]
 
-  # In our AWS one we have twelvelabs api key here, I think it needs to be taken out
+
   environment {
     variables = {
       DB_HOST     = var.db_host
@@ -351,7 +351,7 @@ resource "aws_lambda_function" "kubrick_sqs_embedding_task_consumer" {
     security_group_ids = [aws_security_group.lambda_private_egress_all_sg.id]
   }
 
-  timeout = 900 # 15 minutes timeout
+  timeout = 30 # 30s timeout for embedding tasks
 
 }
 


### PR DESCRIPTION
- change batch size to 1
  - allow aws to manage scaling lambdas (1 per sqs task)
  - this allows us to reduce our lambda timeout and sqs visibility timeout to a reasonable 25 and 30s