### PR TITLE
Tf s3 static site endpoint fix

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,3 +1,5 @@
 data "aws_availability_zones" "available" {
   state = "available"
 }
+
+data "aws_caller_identity" "current" {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -20,8 +20,6 @@ module "iam" {
   secret_arn               = module.secrets_manager.secret_arn
   environment              = local.env
   embedding_task_queue_arn = module.sqs.queue_arn
-
-  depends_on = [module.secrets_manager]
 }
 
 # Public S3 bucket depends on API_Gateway
@@ -40,8 +38,6 @@ module "s3_notifications" {
   delete_lambda_function_arn  = module.lambda.kubrick_s3_delete_handler_arn
   delete_lambda_function_name = module.lambda.kubrick_s3_delete_handler_function_name
   bucket_arn                  = module.s3.bucket_arn
-
-  depends_on = [module.lambda, module.s3]
 }
 
 module "rds" {
@@ -89,10 +85,6 @@ module "lambda" {
   queue_arn                                         = module.sqs.queue_arn
   secrets_manager_name                              = var.secrets_manager_name
   aws_profile                                       = var.aws_profile
-
-  depends_on = [
-    module.rds, module.iam, module.sqs
-  ]
 }
 
 module "sqs" {
@@ -114,8 +106,6 @@ module "api_gateway" {
   upload_link_lambda_function_name  = module.lambda.kubrick_api_video_upload_link_handler_function_name
   fetch_tasks_lambda_function_name  = module.lambda.kubrick_api_fetch_tasks_handler_function_name
   aws_region                        = local.region
-
-  depends_on = [module.lambda]
 }
 
 module "cloudfront" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -91,7 +91,7 @@ module "sqs" {
   source                  = "./modules/sqs"
   environment             = local.env
   enable_queue_policy     = true
-  queue_policy_principals = ["arn:aws:iam::791237609017:root"]
+  queue_policy_principals = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
   queue_policy_actions    = ["SQS:*"]
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -119,9 +119,6 @@ module "api_gateway" {
 }
 
 module "cloudfront" {
-  source                         = "./modules/cloudfront"
-  s3_bucket_regional_domain_name = module.s3.kubrick_playground_bucket_regional_domain_name
-  s3_bucket_arn                  = module.s3.kubrick_playground_bucket_arn
-  aws_region                     = local.region
-  kubrick_playground_bucket_name = module.s3.kubrick_playground_bucket_name
+  source                                     = "./modules/cloudfront"
+  kubrick_playground_bucket_website_endpoint = module.s3.kubrick_playground_bucket_website_endpoint
 }

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -11,7 +11,7 @@ resource "aws_cloudfront_distribution" "kubrick_playground" {
   default_root_object = "index.html"
 
   origin {
-    domain_name = "${var.kubrick_playground_bucket_name}.s3-website-${var.aws_region}.amazonaws.com"
+    domain_name = var.kubrick_playground_bucket_website_endpoint
     origin_id   = "s3-static-website"
 
     custom_origin_config {
@@ -26,8 +26,8 @@ resource "aws_cloudfront_distribution" "kubrick_playground" {
     target_origin_id       = "s3-static-website"
     viewer_protocol_policy = "redirect-to-https"
 
-    allowed_methods  = ["GET", "HEAD"]
-    cached_methods   = ["GET", "HEAD"]
+    allowed_methods = ["GET", "HEAD"]
+    cached_methods  = ["GET", "HEAD"]
 
     forwarded_values {
       query_string = true
@@ -49,14 +49,15 @@ resource "aws_cloudfront_distribution" "kubrick_playground" {
   }
 
   custom_error_response {
-    error_code            = 404
-    response_code         = 200
-    response_page_path    = "/index.html"
+    error_code         = 404
+    response_code      = 200
+    response_page_path = "/index.html"
   }
 
   custom_error_response {
-    error_code            = 403
-    response_code         = 200
-    response_page_path    = "/index.html"
+    error_code         = 403
+    response_code      = 200
+    response_page_path = "/index.html"
   }
 }
+

--- a/terraform/modules/cloudfront/variables.tf
+++ b/terraform/modules/cloudfront/variables.tf
@@ -1,19 +1,5 @@
-variable "s3_bucket_regional_domain_name" {
-  description = "The regional domain name of the S3 bucket (e.g. my-bucket.s3.us-east-1.amazonaws.com)"
+variable "kubrick_playground_bucket_website_endpoint" {
+  description = "The AWS region-specific website endpoint of the Kubrick playground S3 bucket "
   type        = string
 }
 
-variable "s3_bucket_arn" {
-  description = "The ARN of the S3 bucket"
-  type        = string
-}
-
-variable "aws_region" {
-  description = "AWS region"
-  type        = string
-}
-
-variable "kubrick_playground_bucket_name" {
-  description = "The name of the S3 bucket used to serve the Kubrick playground static website"
-  type        = string
-}

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -46,8 +46,8 @@ resource "aws_lambda_layer_version" "s3_utils_layer" {
 
 # Security Group
 resource "aws_security_group" "lambda_private_egress_all_sg" {
-  name        = "kubrick_api_search_handler_sg"
-  description = "Security group for kubrick_api_search_handler Lambda"
+  name        = "kubrick_lambda_vpc_egress_sg"
+  description = "Security group for Lambda that need to send requests/responses outside the VPC"
   vpc_id      = var.vpc_id
 
   # Allows all traffic leaving the lambda (outbound traffic)

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -25,6 +25,11 @@ output "kubrick_playground_bucket_regional_domain_name" {
   value = aws_s3_bucket.kubrick_playground_bucket.bucket_regional_domain_name
 }
 
+output "kubrick_playground_bucket_website_endpoint" {
+  value = aws_s3_bucket_website_configuration.kubrick_playground_bucket.website_endpoint
+}
+
 output "kubrick_playground_bucket_arn" {
   value = aws_s3_bucket.kubrick_playground_bucket.arn
 }
+


### PR DESCRIPTION
- aws_cloudfront_distribution.kubrick_playground.domain_name is not longer generated with string interpolation, but programmatically.
- this solves the issue that different regions have different s3-website url formats. see https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteEndpoints.html?icmpid=docs_amazons3_console
- removed unnecessary `depends_on` in resource blocks
  - depends_on is only necessary for implicit dependencies that terraform cannot infer.
- renamed kubrick_lambda_vpc_egress_sg
  - previous name was kubrick_api_search_handler_sg even though other lambda functions were using it
- queue policy principals value is no longer hardcoded and now pulls from aws sts
- did not change the playground bucket public access, I think it needs to be public to serve cloudfront as a static site
  - seems like the alternative is to serve the playground bucket as a REST API, we can consider changing to that approach